### PR TITLE
Set current DPI scale for HDPI monitors

### DIFF
--- a/Engine/src/Engine/ImGui/ImGuiLayer.cpp
+++ b/Engine/src/Engine/ImGui/ImGuiLayer.cpp
@@ -61,6 +61,8 @@ namespace Engine
         ImGuiIO& io = ImGui::GetIO();
         Application& application = Application::Get();
         io.DisplaySize = ImVec2(application.GetWindow().GetWidth(), application.GetWindow().GetHeight());
+
+        SetDisplaySizeScale();
         
         float time = (float)glfwGetTime();
         io.DeltaTime = m_Time > 0.0f ? (time - m_Time) : (1.0f / 60.0f);
@@ -157,9 +159,17 @@ namespace Engine
     {
         ImGuiIO& io = ImGui::GetIO();
         io.DisplaySize = ImVec2(e.GetWidth(), e.GetHeight());
-        io.DisplayFramebufferScale = ImVec2(1.0f, 1.0f);
         glViewport(0, 0, e.GetWidth(), e.GetHeight());
         
         return false;
+    }
+    
+    void ImGuiLayer::SetDisplaySizeScale()
+    {
+        float xScale, yScale;
+        GLFWwindow* window = glfwGetCurrentContext();
+        glfwGetWindowContentScale(window, &xScale, &yScale);
+        ImGuiIO& io = ImGui::GetIO();
+        io.DisplayFramebufferScale = ImVec2(xScale, yScale);
     }
 }

--- a/Engine/src/Engine/ImGui/ImGuiLayer.cpp
+++ b/Engine/src/Engine/ImGui/ImGuiLayer.cpp
@@ -25,6 +25,11 @@ namespace Engine
         io.BackendFlags |= ImGuiBackendFlags_HasMouseCursors;
         io.BackendFlags |= ImGuiBackendFlags_HasSetMousePos;
         
+        ImGuiStyle& style = ImGui::GetStyle();
+        style.ScaleAllSizes(2);
+        io.FontGlobalScale = 0.5f;
+        io.Fonts->AddFontFromFileTTF("/System/Library/Fonts/SFNS.ttf", 32);
+
         io.KeyMap[ImGuiKey_Tab] = GLFW_KEY_TAB;
         io.KeyMap[ImGuiKey_LeftArrow] = GLFW_KEY_LEFT;
         io.KeyMap[ImGuiKey_RightArrow] = GLFW_KEY_RIGHT;

--- a/Engine/src/Engine/ImGui/ImGuiLayer.h
+++ b/Engine/src/Engine/ImGui/ImGuiLayer.h
@@ -32,6 +32,8 @@ namespace Engine
         bool OnKeyTypedEvent(KeyTypedEvent& e);
         bool OnWindowResizedEvent(WindowResizeEvent& e);
         
+        void SetDisplaySizeScale();
+        
         float m_Time = 0.0f;
     };
 }


### PR DESCRIPTION
# Context
Current Dear ImGui does not have a canonical solution to handle adaptive DPI for multiple monitors.

# Proposed solution
I decided to use the `glfwGetWindowContentScale(window, &xScale, &yScale)` function to get the monitor scale and set the values of `xScale` and `yScale` into the `io.DisplayFramebufferScale`. 
This might not be the best solution, but I will use it to make the UI elements look better in HDPI monitors like MacBooks' Retina Display.

# References
https://github.com/ocornut/imgui/issues/1786
https://github.com/ocornut/imgui/issues/1676
[Why retina screen coordinate value is twice the value of pixel value](https://stackoverflow.com/questions/36672935/why-retina-screen-coordinate-value-is-twice-the-value-of-pixel-value)
[How should I handle DPI in my application?](https://github.com/ocornut/imgui/blob/master/docs/FAQ.md#q-how-should-i-handle-dpi-in-my-application)
https://github.com/ocornut/imgui/issues/1786#issuecomment-523332319